### PR TITLE
Removed hard coded protoc path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,20 +57,9 @@ target_compile_features(citescoop-proto_citescoop-proto PUBLIC cxx_std_20)
 
 find_package(protobuf CONFIG REQUIRED)
 
-find_program(PROTOC_EXECUTABLE
-    NAMES protoc
-    PATHS
-        "${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/x64-linux/tools/protobuf"
-        "${CMAKE_BINARY_DIR}/vcpkg_installed/x64-linux/tools/protobuf"
-        "${CMAKE_SOURCE_DIR}/build/dev/vcpkg_installed/x64-linux/tools/protobuf"
-    NO_DEFAULT_PATH
-    REQUIRED
-)
-
 protobuf_generate(
     TARGET citescoop-proto_citescoop-proto
     LANGUAGE cpp
-    PROTOC_EXECUTABLE ${PROTOC_EXECUTABLE}
 )
 
 target_link_libraries(citescoop-proto_citescoop-proto PUBLIC protobuf::libprotobuf)


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->


# Summary
The call to find executable was causing issues when the library is used with vcpkg.
<!-- A brief, mostly non technical summary of what this change does -->

Closes #

- [ ] Breaking Change?

# Technical Description

Removed the find executable call and just rely on it being found internally.

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Original Bug Description

<!--
A brief description of the original bug that was fixed by this change.
-->

The find executable call restricted where the protoc executable could be found. This caused errors when using this with vcpkg as a library.

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
