### PR TITLE
Fixed the installed include files.

### DIFF
--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -3,7 +3,7 @@
 
 if(PROJECT_IS_TOP_LEVEL)
   set(
-      CMAKE_INSTALL_INCLUDEDIR "include/citescoop-proto-${PROJECT_VERSION}"
+      CMAKE_INSTALL_INCLUDEDIR "include/citescoop/proto"
       CACHE STRING ""
   )
   set_property(CACHE CMAKE_INSTALL_INCLUDEDIR PROPERTY TYPE PATH)
@@ -21,6 +21,8 @@ install(
     "${PROJECT_BINARY_DIR}/src/"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT citescoop-proto_Development
+    FILES_MATCHING
+    PATTERN "*.h"
 )
 
 install(


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

<!-- A brief, mostly non technical summary of what this change does -->
Corrected path so include files appear under citescoop/proto

Corrected install rule so only header files are put in include
Closes #

- [ ] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Original Bug Description

The .cc files were included in the include directory. 

The include directory was citescoop-proto-$VERSION.

<!--
A brief description of the original bug that was fixed by this change.
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
