### PR TITLE
Changed RevisionCitations from holding a list of Citations to a list of ExtractedCitations

### DIFF
--- a/src/revision_citations.proto
+++ b/src/revision_citations.proto
@@ -3,12 +3,12 @@
 
 syntax = "proto3";
 
-import "citation.proto";
+import "extracted_citation.proto";
 import "revision.proto";
 
 package wikiopencite.proto;
 
 message RevisionCitations {
   optional Revision revision = 1;
-  repeated Citation citations = 2;
+  repeated ExtractedCitation citations = 2;
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

<!-- A brief, mostly non technical summary of what this change does -->

Closes #

- [x] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Usage
It doesn't make much sense for the revision to have a list of the citations because at this point, we haven't grouped by citation type. This is technically a breaking change, but given no one actually uses this yet we should be fine.
<!--
How should this change be used? Are there any changes to existing
usage, e.g. API?
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended