### PR TITLE
Semi-finalised the protobuf file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,34 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Citescoop Protobuf Definitions
 
-This repo provides the protobuf definitions library for citescoop datafiles.
+This repo provides the protobuf definitions library for citescoop
+datafiles.
 
-# Building and installing
+## File format
+
+Citescoop `.pbf` files have the following format:
+
+```
+uint32 - Size of header
+FileHeader - see src/file_header.proto
+```
+
+Followed by a number (specified in the file header) of pages as follows:
+
+```
+uint32 - Size of page
+Page - see src/page.proto
+```
+
+## Building and installing
 
 See the [BUILDING](BUILDING.md) document.
 
-# Contributing
+## Contributing
 
 See the [CONTRIBUTING](CONTRIBUTING.md) document.
 
-# Licensing
+## Licensing
 
 This repo uses the [REUSE](https://reuse.software) standard in order to
 communicate the correct license for the file. For those unfamiliar with

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,14 +3,14 @@
 
 add_library(
     citescoop-proto_citescoop-proto
-    citation_group.proto
     citation.proto
     extracted_citation.proto
+    file_header.proto
     identifiers.proto
     language.proto
+    page.proto
     revision_citations.proto
     revision.proto
-    revisions_group.proto
     url.proto
 )
 

--- a/src/file_header.proto
+++ b/src/file_header.proto
@@ -3,10 +3,11 @@
 
 syntax = "proto3";
 
-import "citation.proto";
+import "language.proto";
 
 package wikiopencite.proto;
 
-message CitationGroup {
-  repeated Citation citations = 1;
+message FileHeader {
+  optional int64 page_count = 1;
+  optional Language language = 2;
 }

--- a/src/page.proto
+++ b/src/page.proto
@@ -3,10 +3,12 @@
 
 syntax = "proto3";
 
-import "revision_citations.proto";
+import "citation.proto";
 
 package wikiopencite.proto;
 
-message RevisionsGroup {
-  repeated RevisionCitations revisions = 1;
+message Page {
+  optional string title = 1;
+  optional int64 page_id = 2;
+  repeated Citation citations = 3;
 }

--- a/src/revision.proto
+++ b/src/revision.proto
@@ -5,14 +5,12 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 
-import "language.proto";
 
 package wikiopencite.proto;
 
 message Revision {
-  optional Language language = 1;
-  optional int64 revision_id = 2;
-  optional int64 parent_id = 3;
-  optional string user = 4;
-  optional google.protobuf.Timestamp timestamp = 5;
+  optional int64 revision_id = 1;
+  optional int64 parent_id = 2;
+  optional string user = 3;
+  optional google.protobuf.Timestamp timestamp = 4;
 }

--- a/src/revision_citations.proto
+++ b/src/revision_citations.proto
@@ -10,5 +10,5 @@ package wikiopencite.proto;
 
 message RevisionCitations {
   optional Revision revision = 1;
-  repeated ExtractedCitation citations = 2;
+  map<string,ExtractedCitation> citations = 2;
 }


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

<!-- A brief, mostly non technical summary of what this change does -->
After having a look at the dump format, the file format has been mostly finalised.

Closes #

- [x] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

The file format roughly follows the format of the data dumps. It contains multiple pages with citations for each page. Some inspiration was taken from the Open Street Map pbf format (https://wiki.openstreetmap.org/wiki/PBF_Format#File_format)

## Usage

<!--
How should this change be used? Are there any changes to existing
usage, e.g. API?
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
