### PR TITLE
Change to more normalised revision storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Citescoop `.pbf` files have the following format:
 ```
 uint32 - Size of header
 FileHeader - see src/file_header.proto
+uint32 - Size of revisions map
+RevisionMap - see src/revision_map.proto
 ```
 
 Followed by a number (specified in the file header) of pages as follows:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
     language.proto
     page.proto
     revision_citations.proto
+    revision_map.proto
     revision.proto
     url.proto
 )

--- a/src/citation.proto
+++ b/src/citation.proto
@@ -4,12 +4,11 @@
 syntax = "proto3";
 
 import "extracted_citation.proto";
-import "revision.proto";
 
 package wikiopencite.proto;
 
 message Citation {
   optional ExtractedCitation citation = 1;
-  optional Revision revision_added = 2;
-  optional Revision revision_removed = 3;
+  optional int64 revision_added = 2;
+  optional int64 revision_removed = 3;
 }

--- a/src/revision_map.proto
+++ b/src/revision_map.proto
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+syntax = "proto3";
+
+import "revision.proto";
+
+package wikiopencite.proto;
+
+message RevisionMap {
+  map<int64, Revision> revisions = 1;
+}


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
Instead of having a complete copy of the revision for each citation, store only the ID and instead have a message at the start of the file storing them all in a map.
<!-- A brief, mostly non technical summary of what this change does -->

Closes #

- [x] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Usage

<!--
How should this change be used? Are there any changes to existing
usage, e.g. API?
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
