### PR TITLE
 Add proto representation for OpenAlex dataset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(cmake/prelude.cmake)
 
 project(
     citescoop-proto
-    VERSION 0.5.0
+    VERSION 0.6.0
     DESCRIPTION "Protobuf definitions for citescoop data files"
     HOMEPAGE_URL "https://github.com/WikiOpenCite/citescoop"
     LANGUAGES CXX

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,9 @@ add_library(
     revision_citations.proto
     revision.proto
     url.proto
+    openalex/author.proto
+    openalex/institution.proto
+    openalex/work.proto
 )
 
 add_library(wikiopencite::proto ALIAS citescoop-proto_citescoop-proto)

--- a/src/openalex/author.proto
+++ b/src/openalex/author.proto
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+syntax = "proto3";
+
+package wikiopencite.proto.openalex;
+
+message Author {
+  optional string openalex_id = 1;
+  optional string name = 2;
+  optional string orcid = 3;
+}

--- a/src/openalex/institution.proto
+++ b/src/openalex/institution.proto
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+syntax = "proto3";
+
+package wikiopencite.proto.openalex;
+
+message Institution {
+  optional string openalex_id = 1;
+  optional string name = 2;
+  optional string ror = 3;
+}

--- a/src/openalex/work.proto
+++ b/src/openalex/work.proto
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "language.proto";
+import "identifiers.proto";
+
+package wikiopencite.proto.openalex;
+
+message Work {
+  optional string openalex_id = 1;
+  optional string title = 2;
+  optional google.protobuf.Timestamp publication_date = 3;
+  optional wikiopencite.proto.Language language = 4;
+  optional Work.OACategory oa_status = 5;
+  optional string oa_url = 6;
+  repeated string author_ids = 7;
+  repeated string institution_ids = 8;
+  optional wikiopencite.proto.Identifiers ids = 9;
+
+
+  enum OACategory {
+    OA_CATEGORY_UNSPECIFIED = 0;
+    OA_CATEGORY_DIAMOND = 1;
+    OA_CATEGORY_GOLD = 2;
+    OA_CATEGORY_GREEN = 3;
+    OA_CATEGORY_HYBRID = 4;
+    OA_CATEGORY_BRONZE = 5;
+    OA_CATEGORY_CLOSED = 6;
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "citescoop-proto",
-  "version-semver": "0.5.0",
+  "version-semver": "0.6.0-alpha.1",
   "builtin-baseline": "74e6536215718009aae747d86d84b78376bf9e09",
   "dependencies": [
     {


### PR DESCRIPTION




<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary
 
Add proto representation for OpenAlex dataset. Also bumped to 0.6.0-alpha.1. Using an alpha tag because we need to release to use with the libraries but we still don't entirely know what protos we need.

<!-- A brief, mostly non technical summary of what this change does -->

Closes #30 

- [ ] Breaking Change?

# Technical Description

Three more messages and a enum in a new sub namespace `wikiopencite.proto.openalex`. The new namespace is mainly for just keeping it nice and separate.

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Usage

<!--
How should this change be used? Are there any changes to existing
usage, e.g. API?
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
