### PR TITLE
Moved to vcpkg config

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,7 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
+    "repository": "https://github.com/microsoft/vcpkg"
+  }
+}

--- a/vcpkg-configuration.json.license
+++ b/vcpkg-configuration.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 The University of St Andrews
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "citescoop-proto",
   "version-semver": "0.6.0-alpha.2",
-  "builtin-baseline": "f3e10653cc27d62a37a3763cd84b38bca07c6075",
   "dependencies": [
     {
       "name": "protobuf",


### PR DESCRIPTION
This removes the dependency on the CI build system env var which isn't picked up by dependabot

